### PR TITLE
Add remaining double out attempts to data sent to match server

### DIFF
--- a/app/src/main/java/com/fraz/dartlog/game/x01/X01GameActivity.java
+++ b/app/src/main/java/com/fraz/dartlog/game/x01/X01GameActivity.java
@@ -179,6 +179,11 @@ public class X01GameActivity extends AppCompatActivity implements
         player1data.put("matchdata", player1list);
         player2data.put("matchdata", player2list);
 
+        int player1doubles = ((X01PlayerData) player1).getRemainingDoubleOutAttempts();
+        int player2doubles = ((X01PlayerData) player2).getRemainingDoubleOutAttempts();
+        player1data.put("double_out", player1doubles);
+        player2data.put("double_out", player2doubles);
+
         Map match = new HashMap();
         match.put("winner", winner);
         match.put("player1", player1data);


### PR DESCRIPTION
Jag castade till X01PlayerData på plats, efter att ha försäkrat mig om att det alltid är den typen det är. Man skulle kunna ändra så att X01GameActivity alltid har en X01PlayerData, eftersom det alltid är sant. Jag vet inte